### PR TITLE
Default name to 'drawing' if svg has not been saved

### DIFF
--- a/inkscape/svg2shenzhen/export.py
+++ b/inkscape/svg2shenzhen/export.py
@@ -469,6 +469,8 @@ class Svg2ShenzhenExport(inkex.Effect):
     def get_name(self):
         root = self.document.getroot()
         docname = root.get('{http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd}docname')
+        if docname is None:
+            return 'drawing'
         return os.path.splitext(docname)[0]
 
     def get_layers(self, src):


### PR DESCRIPTION
Currently, there is an error if you use export from an unsaved document. This fixes that by calling it "drawing" which is what inkscape calls svgs by default.