### PR TITLE
Update svg2shenzhen_export.inx

### DIFF
--- a/inkscape/svg2shenzhen_export.inx
+++ b/inkscape/svg2shenzhen_export.inx
@@ -10,7 +10,7 @@
        <option value="kicad_module">KICAD - Module</option>
        <option value="png">PNG - Image</option>
     </param>
-    <param name="threshold" type="int" min="0" max="255" _gui-text="Threshold (default: 128)">128</param>
+    <param name="threshold" type="int" min="0" max="255" _gui-text="Threshold (default: 5)">5</param>
     <param name="dpi" type="int" min="0" max="2000" _gui-text="Export DPI (default: 600)">600</param>
     <param name="autoflatten" type="boolean" gui-text="Auto flatten bezier for Edge.Cuts layer?">true</param>
     <param name="debug" type="boolean" gui-text="Debug Mode?">false</param>


### PR DESCRIPTION
any reason why we can't have the default threshold set lower. 
this comes up in a few issues and tutorials. i've been using threshold=5 for a long time without any issues.