### PR TITLE
Update link to svg2mod repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ This project is developed independently and without any connection to funding or
 * inkscape-export-layers - https://github.com/jespino/inkscape-export-layers
 * bitmap2component (kicad) - https://github.com/KiCad/kicad-source-mirror/tree/master/bitmap2component
 * csv_output - https://github.com/tbekolay/csv_output
-* svg2mod - https://github.com/mtl/svg2mod
+* svg2mod - https://github.com/svg2mod/svg2mod


### PR DESCRIPTION
In the readme this project links to the original svg2mod repo by @mtl, but he hasn't been active in years so [in an effort to not let the project die](https://github.com/mtl/svg2mod/issues/37) [a new, active repo has been created](https://github.com/svg2mod/svg2mod). 

Can the readme be updated to reflect the new active repo to avoid confusion and allow people to find the most up to date code easier?