### PR TITLE
added a tar version of the release package for linux installations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,9 @@ rm -fr $cwd/$BUILD_DIR/$BUILD_DIR_STAGING/*.bak
 
 cd $cwd/$BUILD_DIR/$BUILD_DIR_STAGING
 
-zip -m -x .DS_Store -r $cwd/$BUILD_DIR/${RELEASE_FILENAME_PREFIX}-${GIT_TAG_VERSION}.zip .
+zip -x .DS_Store -r $cwd/$BUILD_DIR/${RELEASE_FILENAME_PREFIX}-${GIT_TAG_VERSION}.zip .
+
+tar -czf $cwd/$BUILD_DIR/${RELEASE_FILENAME_PREFIX}-${GIT_TAG_VERSION}.tar.gz --exclude .DS_Store --exclude '.zip' --remove-files *
 
 cd $cwd
 


### PR DESCRIPTION
This is a small update to the build script to create a tar ball as well as the current zip. The main reason for this is #52 is still a problem with the current zip release. This should solve the problem since the linux elf file is retaining it's executable permissions within the tar.