### PR TITLE
Prepare Document UI & Backend Overhaul

### DIFF
--- a/inkscape/svg2shenzhen_about.inx
+++ b/inkscape/svg2shenzhen_about.inx
@@ -8,7 +8,7 @@
 	<page name='about' _gui-text='About'>	
 		<_param name="help" type="description">		
 Svg2Shenzhen version SVGSZ_VER
-Inkscape extension for exporting drawing into Kicad PCB
+Inkscape extension to export drawing as a KiCad Module or KiCad Project
 
 Get New Update:
 https://github.com/badgeek/svg2shenzhen

--- a/inkscape/svg2shenzhen_prepare.inx
+++ b/inkscape/svg2shenzhen_prepare.inx
@@ -3,11 +3,42 @@
     <_name>1. Prepare Document</_name>
     <id>net.svg2shenzhen.prepare.doc</id>
     <dependency type="executable" location="extensions">svg2shenzhen/prepare.py</dependency>
-	<param name="help" type="description">Prepare document for Kicad Export</param>
-    <param name="docwidth" type="float" min="0.0" max="100000.0" _gui-text="Document width (mm)">100</param>
-    <param name="docheight" type="float" min="0.0" max="100000.0" _gui-text="Document height (mm)">100</param>
-    <param name="version" type="description">SVG2SHENZHEN SVGSZ_VER</param>
-
+    <param name="name" type="notebook">
+        <page name="Tab1" _gui-text="General">
+            <label appearance="header">Prepare Document For KiCad Export</label>
+            <param name="docwidth" type="float" min="0.0" max="100000.0" _gui-text="Document Width (mm)">100</param>
+            <param name="docheight" type="float" min="0.0" max="100000.0" _gui-text="Document Height (mm)">100</param>
+            <separator />
+            <param name="descr" type="description" appearance="header" _gui-description="Layers can be disabled after being created by adding '-disabled' to the layer name e.g. 'F.SilkS-disabled'">Select Layers To Use (!)</param>
+            <param name="layerDrill" type="boolean" _gui-text="Drill" indent="2">true</param>
+            <param name="layerDwgs_user" type="boolean" _gui-text="Dwgs.User" indent="2">true</param>
+            <param name="layerF_Silks" type="boolean" _gui-text="F.SilkS" indent="2">true</param>
+            <param name="layerF_mask" type="boolean" _gui-text="F.Mask" indent="2">true</param>
+            <param name="layerF_cu" type="boolean" _gui-text="F.Cu" indent="2">true</param>
+            <param name="layerB_silks" type="boolean" _gui-text="B.SilkS" indent="2">true</param>
+            <param name="layerB_mask" type="boolean" _gui-text="B.Mask" indent="2">true</param>
+            <param name="layerB_cu" type="boolean" _gui-text="B.Cu" indent="2">true</param>
+            <param name="layerEdge_Cuts" type="boolean" _gui-text="Edge.Cuts" indent="2"></param>
+        </page>
+        <page name="Tab2" _gui-text="Other">
+            <param name="docGrid" type="boolean" _gui-text="Enable Grid View">false</param>
+            <separator />
+            <label appearance="header">Optional Layers:</label>
+            <param name="layerF_Paste" type="boolean" _gui-text="F.Paste" indent="2">false</param>
+            <param name="layerB_paste" type="boolean" _gui-text="B.Paste" indent="2">false</param>
+            <param name="layerF_Adhes" type="boolean" _gui-text="F.Adhes" indent="2">false</param>
+            <param name="layerB_Adhes" type="boolean" _gui-text="B.Adhes" indent="2">false</param>
+            <param name="layerCmts_User" type="boolean" _gui-text="Cmts.User" indent="2">false</param>
+            <param name="layerEco1_User" type="boolean" _gui-text="Eco1.User" indent="2">false</param>
+            <param name="layerEco2_User" type="boolean" _gui-text="Eco2.User" indent="2">false</param>
+            <param name="layerMargin" type="boolean" _gui-text="Margin" indent="2">false</param>
+            <param name="layerB_CrtYd" type="boolean" _gui-text="B.CrtYd" indent="2">false</param>
+            <param name="layerF_CrtYd" type="boolean" _gui-text="F.CrtYd" indent="2">false</param>
+            <param name="layerB_Fab" type="boolean" _gui-text="B.Fab" indent="2">false</param>
+            <param name="layerF_Fab" type="boolean" _gui-text="F.Fab" indent="2">false</param>
+        </page>
+    </param>
+    <label>SVG2SHENZHEN SVGSZ_VER</label>
     <effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu _name="Prepare Document">

--- a/inkscape/svg2shenzhen_prepare.inx
+++ b/inkscape/svg2shenzhen_prepare.inx
@@ -10,32 +10,32 @@
             <param name="docheight" type="float" min="0.0" max="100000.0" _gui-text="Document Height (mm)">100</param>
             <separator />
             <param name="descr" type="description" appearance="header" _gui-description="Layers can be disabled after being created by adding '-disabled' to the layer name e.g. 'F.SilkS-disabled'">Select Layers To Use (!)</param>
-            <param name="layerDrill" type="boolean" _gui-text="Drill" indent="2">true</param>
-            <param name="layerDwgs_user" type="boolean" _gui-text="Dwgs.User" indent="2">true</param>
-            <param name="layerF_Silks" type="boolean" _gui-text="F.SilkS" indent="2">true</param>
-            <param name="layerF_mask" type="boolean" _gui-text="F.Mask" indent="2">true</param>
-            <param name="layerF_cu" type="boolean" _gui-text="F.Cu" indent="2">true</param>
-            <param name="layerB_silks" type="boolean" _gui-text="B.SilkS" indent="2">true</param>
-            <param name="layerB_mask" type="boolean" _gui-text="B.Mask" indent="2">true</param>
-            <param name="layerB_cu" type="boolean" _gui-text="B.Cu" indent="2">true</param>
-            <param name="layerEdge_Cuts" type="boolean" _gui-text="Edge.Cuts" indent="2"></param>
+            <param name="layerDrill" type="boolean" gui-text="Drill" indent="2">true</param>
+            <param name="layerDwgs_user" type="boolean" gui-text="Dwgs.User" indent="2">true</param>
+            <param name="layerF_Silks" type="boolean" gui-text="F.SilkS" indent="2">true</param>
+            <param name="layerF_mask" type="boolean" gui-text="F.Mask" indent="2">true</param>
+            <param name="layerF_cu" type="boolean" gui-text="F.Cu" indent="2">true</param>
+            <param name="layerB_silks" type="boolean" gui-text="B.SilkS" indent="2">true</param>
+            <param name="layerB_mask" type="boolean" gui-text="B.Mask" indent="2">true</param>
+            <param name="layerB_cu" type="boolean" gui-text="B.Cu" indent="2">true</param>
+            <param name="layerEdge_Cuts" type="boolean" gui-text="Edge.Cuts" indent="2"></param>
         </page>
         <page name="Tab2" _gui-text="Other">
             <param name="docGrid" type="boolean" _gui-text="Enable Grid View">false</param>
             <separator />
             <label appearance="header">Optional Layers:</label>
-            <param name="layerF_Paste" type="boolean" _gui-text="F.Paste" indent="2">false</param>
-            <param name="layerB_paste" type="boolean" _gui-text="B.Paste" indent="2">false</param>
-            <param name="layerF_Adhes" type="boolean" _gui-text="F.Adhes" indent="2">false</param>
-            <param name="layerB_Adhes" type="boolean" _gui-text="B.Adhes" indent="2">false</param>
-            <param name="layerCmts_User" type="boolean" _gui-text="Cmts.User" indent="2">false</param>
-            <param name="layerEco1_User" type="boolean" _gui-text="Eco1.User" indent="2">false</param>
-            <param name="layerEco2_User" type="boolean" _gui-text="Eco2.User" indent="2">false</param>
-            <param name="layerMargin" type="boolean" _gui-text="Margin" indent="2">false</param>
-            <param name="layerB_CrtYd" type="boolean" _gui-text="B.CrtYd" indent="2">false</param>
-            <param name="layerF_CrtYd" type="boolean" _gui-text="F.CrtYd" indent="2">false</param>
-            <param name="layerB_Fab" type="boolean" _gui-text="B.Fab" indent="2">false</param>
-            <param name="layerF_Fab" type="boolean" _gui-text="F.Fab" indent="2">false</param>
+            <param name="layerF_Paste" type="boolean" gui-text="F.Paste" indent="2">false</param>
+            <param name="layerB_paste" type="boolean" gui-text="B.Paste" indent="2">false</param>
+            <param name="layerF_Adhes" type="boolean" gui-text="F.Adhes" indent="2">false</param>
+            <param name="layerB_Adhes" type="boolean" gui-text="B.Adhes" indent="2">false</param>
+            <param name="layerCmts_User" type="boolean" gui-text="Cmts.User" indent="2">false</param>
+            <param name="layerEco1_User" type="boolean" gui-text="Eco1.User" indent="2">false</param>
+            <param name="layerEco2_User" type="boolean" gui-text="Eco2.User" indent="2">false</param>
+            <param name="layerMargin" type="boolean" gui-text="Margin" indent="2">false</param>
+            <param name="layerB_CrtYd" type="boolean" gui-text="B.CrtYd" indent="2">false</param>
+            <param name="layerF_CrtYd" type="boolean" gui-text="F.CrtYd" indent="2">false</param>
+            <param name="layerB_Fab" type="boolean" gui-text="B.Fab" indent="2">false</param>
+            <param name="layerF_Fab" type="boolean" gui-text="F.Fab" indent="2">false</param>
         </page>
     </param>
     <label>SVG2SHENZHEN SVGSZ_VER</label>


### PR DESCRIPTION
Completely overhauled the user interface for Prepare document.
### User Interface
- Added checkboxes for the individual layers that can be added to the document.
- Commonly used and recommend layers are checked by default.
- Cleaned up the UI by adding Tabs to the interface.
- Frequently used options and Layers are on the General Tab
- Lesser used options are now on the "Others" Tab.
- Disabled the Grid View that was added when documents were prepared but created a field on the "Other" tab to re-enable it if you would like
- Newly created layers will no longer be named "Layer-disabled" by default now, however you can still disable them by adding "-disabled" to the end of the layer name.  A tool tip for this has been added to the "Select Layers to Use (!)" header.

### Backend
- Cleaned up the source code in the .inx for the interface and the prepare.py file for better readability and scalability
- In Prepare.py there is now a "kicadLayers" dictionary that can easily be updated and added to as necessary to create the appropriate layers in Inkscape.
- Replaced a massive block of If Statements with a for loop to create the appropriate arguments and layers.

![image](https://user-images.githubusercontent.com/5308062/90467301-e441c380-e0e1-11ea-8ae4-d43dc73b9cff.png)
![image](https://user-images.githubusercontent.com/5308062/90467875-3cc59080-e0e3-11ea-8f1d-cb54bf084e66.png)

