### PR TITLE
Export Interface & About Interface Tweaks

### DIFF
--- a/inkscape/svg2shenzhen/export.py
+++ b/inkscape/svg2shenzhen/export.py
@@ -14,7 +14,11 @@ import pickle
 from copy import deepcopy
 from inkex import bezier
 from inkex.transforms import Transform
+from pathlib import Path
 
+
+homePath = str()
+homePath = Path.home()
 
 EXPORT_PNG_MAX_PROCESSES = 3
 EXPORT_KICAD_MAX_PROCESSES = 2
@@ -254,7 +258,7 @@ class Svg2ShenzhenExport(inkex.Effect):
         }
 
     def add_arguments(self, pars):
-        pars.add_argument("--path", default="~/")
+        pars.add_argument("--path", default=homePath)
         pars.add_argument('-f', '--filetype', default='jpeg', help='Exported file type')
         pars.add_argument("--crop", type=inkex.Boolean, default=False)
         pars.add_argument("--dpi", type=int, default=600)
@@ -338,7 +342,12 @@ class Svg2ShenzhenExport(inkex.Effect):
     def processExportLayer(self):
         options = self.options
 
-        output_path = os.path.expanduser(options.path)
+        if os.path.dirname(os.getcwd()) == options.path:
+            inkex.errormsg('EXPORT ERROR! Please Select A Directory To Export To!')
+            exit()
+        else:
+            output_path = os.path.expanduser(options.path)
+
         curfile = self.options.input_file
         layers = self.get_layers(curfile)
         name = self.get_name()

--- a/inkscape/svg2shenzhen_about.inx
+++ b/inkscape/svg2shenzhen_about.inx
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <_name>0. Help</_name>
+    <_name>About</_name>
     <id>net.svg2shenzhen.about.me</id>
 	<param name='active-tab' type="notebook">
+		<page name='about' _gui-text='About'>	
+			<label appearance="header">Svg2Shenzhen Ver. SVGSZ_VER</label>
+			<separator />
+<_param name="help" type="description" xml:space="preserve">Inkscape Extension to Export Drawings as a KiCad Module or KiCad Project
 
-	<page name='about' _gui-text='About'>	
-		<_param name="help" type="description">		
-Svg2Shenzhen version SVGSZ_VER
-Inkscape extension to export drawing as a KiCad Module or KiCad Project
+To get updates, get help, review the source, or contribute please visit the project's GitHub page.
 
-Get New Update:
-https://github.com/badgeek/svg2shenzhen
-
-Support this software:
-https://patreon.com/badgeek
-
-
-		</_param>
-	</page>
-
+Thank you to everyone who has contributed to Svg2Shenzhen.</_param>
+			<separator />
+			<label>Project GitHub</label>
+			<label indent="2" appearance="url">https://github.com/badgeek/svg2shenzhen</label>
+			<separator />
+			<label>Support the Author:</label>
+			<label indent="2" appearance="url">https://patreon.com/badgeek</label>
+		</page>
 	</param>	
     <effect needs-live-preview="false">
         <effects-menu _name="About">
@@ -27,5 +25,4 @@ https://patreon.com/badgeek
 		</effects-menu>
 		<object-type>all</object-type>
     </effect>
-
 </inkscape-extension>

--- a/inkscape/svg2shenzhen_export.inx
+++ b/inkscape/svg2shenzhen_export.inx
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <_name>2. Export Kicad</_name>
+    <_name>2. Export to KiCad</_name>
     <id>net.svg2shenzhen.export.layers</id>
     <dependency type="executable" location="extensions">svg2shenzhen/export.py</dependency>
-	<param name="help" type="description">Export Drawing to KiCad PCB Format</param>
-    <param type="path" name="path" _gui-text="Choose Path to Export" mode="folder"/>
-    <param name="filetype" type="optiongroup" gui-text="Export layers as..." appearance="minimal">
-       <option selected="selected"  value="kicad_module">KiCad - Module</option>
-       <option value="kicad_pcb">KiCad - Project</option>
+	<label appearance="header">Export Drawing to KiCad</label>
+    <param type="path" name="path" _gui-text="Folder" mode="folder"/>
+    <param name="filetype" type="optiongroup" gui-text="Export As (!)" appearance="minimal" _gui-description="Module is a single KiCad Module, or Part, that contains all of the layers.  This is the recommended way to use this plugin.  Project exports the drawing as a entire KiCad project with the layers separated into their own modules.  PNG exports all of the layers a PNG Image file.">
+       <option selected="selected"  value="kicad_module">Module</option>
+       <option value="kicad_pcb">Project</option>
        <option value="png">PNG - Image</option>
     </param>
-    <param name="threshold" type="int" min="0" max="255" _gui-text="Threshold (default: 5)">5</param>
-    <param name="dpi" type="int" min="0" max="3600" _gui-text="Export DPI (default: 1200)">1200</param>
-    <param name="autoflatten" type="boolean" gui-text="Auto flatten bezier for Edge.Cuts layer?">true</param>
-    <param name="debug" type="boolean" gui-text="Debug Mode?">false</param>
-    <param name="openfactory" type="boolean" gui-text="Open PCBWay after export?">true</param>
-    <param name="openkicad" type="boolean" gui-text="Open Kicad after export?">false</param>
-
+    <param name="threshold" type="int" min="0" max="255" _gui-text="Threshold (!)" _gui-description="Default: 5 - Define the threshold the black and white will have.">5</param>
+    <param name="dpi" type="int" min="0" max="3600" _gui-text="Export DPI (!)" _gui-description="Default: 1200 - Define the Dots Per Inch to Export the Layers at, recommended is 1,200, max is 3,600.  Below 1,200 you may see artifacts due to the low resolution.">1200</param>
+    <separator />
+    <param name="autoflatten" type="boolean" _gui-text="Flatten Bezier (!)" _gui-description="Select this option if you have not flattened the Bezier Curves on your Edge.Cut layer.  If this is not the first time you have exported this drawing do not check this option.">false</param>
+    <param name="openfactory" type="boolean" gui-text="Open PCBWay (!)" _gui-description="Opens the PCBWay website with an affiliate link for you to submit an order.">false</param>
+    <param name="openkicad" type="boolean" gui-text="Open KiCad (!)" _gui-description="Opens the KiCad for you.">false</param>
+    <param name="debug" type="boolean" _gui-text="Debug Mode" _gui-description="Only necessary for troubleshooting.">false</param>
+    <separator />
+    <label>SVG2SHENZHEN SVGSZ_VER</label>
     <effect needs-live-preview="false">
         <object-type>all</object-type>
         <effects-menu _name="Export Kicad">


### PR DESCRIPTION
### Export Interface

- Adjusted the UI to be more in line with the updated Prepare interface.
- Adjusted the Default "path" to be the user's Home Path as suggested in Issue #83 by cglmrfreeman however his suggested solution to accomplish this was not feasible as it doesn't work in some OSs.   The Inkscape INX default path in path fields is the extension directory itself so even if it is left blank it is not actually empty.  The updated export.py reviews the export path and if it is the same as the Extension directory it is assumed that the Folder path was left blank and throws an error reminding the user to select a folder and stops the export process.
- Shortened most of the text and added Tool Tips to all fields to provide more detail as to their function.

### About Interface (Previously Help)

- Adjusted the UI to be more in line with the updated Prepare interface.
- Changed the name to reflect the content of the interface.
- Cleaned up the writing and made the links interactive. 

![image](https://user-images.githubusercontent.com/5308062/90559199-44c91300-e16b-11ea-885b-3bced6af2906.png)
![image](https://user-images.githubusercontent.com/5308062/90558879-c66c7100-e16a-11ea-8972-44100b01eabe.png)
