### PR TITLE
Artwork + DRC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,77 +1,76 @@
 jobs:
   include:
-  - stage: unit tests
-    os: windows
-    workspaces:
-      create:
-        name: windows-binaries
-        paths:
-        - bitmap2component.exe
-    language: cpp
-    compiler: cl
-    script:
-    - choco install make
-    - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
-    - unzip boost.zip
-    - mv boost src
-    - make
-  - stage: unit tests
-    os: linux
-    workspaces:
-      create:
-        name: linux-binaries
-        paths:
-        - bitmap2component_linux64
-    language: cpp
-    dist: trusty
-    script:
-    - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
-    - unzip boost.zip
-    - mv boost src
-    - make
-    - mv bitmap2component bitmap2component_linux64
-  - stage: unit tests
-    os: osx
-    workspaces:
-      create:
-        name: osx-binaries
-        paths:
-        - bitmap2component_osx
-    osx_image: xcode12u
-    language: cpp
-    script:
-    - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
-    - unzip boost.zip
-    - mv boost src
-    - make
-    - mv bitmap2component bitmap2component_osx
-  - stage: deploy
-    os: osx
-    language: minimal
-    sudo: true
-    workspaces:
-      use:
-      - linux-binaries
-      - osx-binaries
-      - windows-binaries
-    git:
-      clone: true
-    script:
-    - tar -zxvf ${CASHER_DIR}/linux-binaries-fetch.tgz
-    - tar -zxvf ${CASHER_DIR}/osx-binaries-fetch.tgz
-    - tar -zxvf ${CASHER_DIR}/windows-binaries-fetch.tgz
-    - mv home/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component_linux64 ./inkscape/svg2shenzhen/bitmap2component_linux64
-    - mv ./C:/Users/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component.exe
-      ./inkscape/svg2shenzhen/bitmap2component.exe
-    - mv ./bitmap2component_osx ./inkscape/svg2shenzhen/
-    - sh build.sh
-    deploy:
-      provider: releases
-      api_key:
-        secure: YTQy7sk6uuKvvln8MZmC+raWsT1Fkk+HJ+NS1LlO3TICHElKJvKxvjN7fEU1sQObCCizqMimqQ1ZLBsBMIj1NI8JLsqJsfMQgaU3OV4XbHHfYuDkTwFLC/epPYWshS89Rg7KwhAqD+Ws43PYiCXoRo9Z8Zosd4xxQbFY6K49Q01tHc+o1++nhYENjh2o/sNl7lJUU4oizsgQdsW/yMlJcwnXZHYj1A/sZYsZ3RjvdQ6KuUVVpYZx/QobHvC1VeORmJ66FT2gbamPPklqtr4WKY+965KmbiWrtFOto+mF/7nygIP2RrT4NdYDO9ded9swnBUyav+kKTKUW1l2GrvAJoiUs0vYC6J/H4irtHgXqh9rvbi77Whwpm9hZQFmXXzNjP3KWLH4H5q/nPA17cMI/by+kvuCNpAoEeHDK+4Tf3j+EgHs1it/usZgoA9NAMftArwzHfvQKnUB11pthnAQvk/S3U04sYXezvQkfLz6wxZcv1xMhuiU8Muz3gcXEFquVSjzFH6hgMfLSM/eFR3hVPU49EXDyF/5T1JlCaRI5fa9331nkGIOHjwlbrEwhyvWpW9FeT2RIXZIkQ37J5sd09Tzz7Cs8zCxB1S2mMDfn7KFkb/aP63JmRs4Otmr0k0+3BmuDhbFOcC6yFXTMl5es9ZQLHN/vl448QVZReuI27w=
-      file_glob: true
-      file: dist/*.*
-      skip_cleanup: true
-      on:
-        tags: true
-        branch: master
+    - stage: unit tests
+      os: windows
+      workspaces:
+        create:
+          name: windows-binaries
+          paths:
+          - bitmap2component.exe
+      language: cpp
+      compiler: cl
+      script:
+      - choco install make
+      - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
+      - unzip boost.zip
+      - mv boost src
+      - make
+    - stage: unit tests
+      os: linux
+      workspaces:
+        create:
+          name: linux-binaries
+          paths:
+          - bitmap2component_linux64
+      language: cpp
+      dist: trusty
+      script:
+      - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
+      - unzip boost.zip
+      - mv boost src
+      - make
+      - mv bitmap2component bitmap2component_linux64
+    - stage: unit tests
+      os: osx
+      workspaces:
+        create:
+          name: osx-binaries
+          paths:
+          - bitmap2component_osx
+      osx_image: xcode12u
+      language: cpp
+      script:
+      - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
+      - unzip boost.zip
+      - mv boost src
+      - make
+      - mv bitmap2component bitmap2component_osx
+    - stage: deploy
+      os: osx
+      language: minimal
+      sudo: true
+      workspaces:
+        use:
+        - linux-binaries
+        - osx-binaries
+        - windows-binaries
+      git:
+        clone: true
+      script:
+      - tar -zxvf ${CASHER_DIR}/linux-binaries-fetch.tgz
+      - tar -zxvf ${CASHER_DIR}/osx-binaries-fetch.tgz
+      - tar -zxvf ${CASHER_DIR}/windows-binaries-fetch.tgz
+      - mv home/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component_linux64 ./inkscape/svg2shenzhen/bitmap2component_linux64
+      - mv ./C:/Users/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component.exe ./inkscape/svg2shenzhen/bitmap2component.exe
+      - mv ./bitmap2component_osx ./inkscape/svg2shenzhen/
+      - sh build.sh
+      deploy:
+        provider: releases
+        api_key:
+          secure: YTQy7sk6uuKvvln8MZmC+raWsT1Fkk+HJ+NS1LlO3TICHElKJvKxvjN7fEU1sQObCCizqMimqQ1ZLBsBMIj1NI8JLsqJsfMQgaU3OV4XbHHfYuDkTwFLC/epPYWshS89Rg7KwhAqD+Ws43PYiCXoRo9Z8Zosd4xxQbFY6K49Q01tHc+o1++nhYENjh2o/sNl7lJUU4oizsgQdsW/yMlJcwnXZHYj1A/sZYsZ3RjvdQ6KuUVVpYZx/QobHvC1VeORmJ66FT2gbamPPklqtr4WKY+965KmbiWrtFOto+mF/7nygIP2RrT4NdYDO9ded9swnBUyav+kKTKUW1l2GrvAJoiUs0vYC6J/H4irtHgXqh9rvbi77Whwpm9hZQFmXXzNjP3KWLH4H5q/nPA17cMI/by+kvuCNpAoEeHDK+4Tf3j+EgHs1it/usZgoA9NAMftArwzHfvQKnUB11pthnAQvk/S3U04sYXezvQkfLz6wxZcv1xMhuiU8Muz3gcXEFquVSjzFH6hgMfLSM/eFR3hVPU49EXDyF/5T1JlCaRI5fa9331nkGIOHjwlbrEwhyvWpW9FeT2RIXZIkQ37J5sd09Tzz7Cs8zCxB1S2mMDfn7KFkb/aP63JmRs4Otmr0k0+3BmuDhbFOcC6yFXTMl5es9ZQLHN/vl448QVZReuI27w=
+        file_glob: true
+        file: "dist/*.*"
+        skip_cleanup: true
+        on:
+          tags: true
+          branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,76 +1,77 @@
 jobs:
   include:
-    - stage: unit tests
-      os: windows
-      workspaces:
-        create:
-          name: windows-binaries
-          paths:
-            - bitmap2component.exe
-      language: cpp
-      compiler: cl
-      script:
-      - choco install make
-      - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
-      - unzip boost.zip
-      - mv boost src
-      - make
-    - stage: unit tests
-      os: linux
-      workspaces:
-        create:
-          name: linux-binaries
-          paths:
-            - bitmap2component_linux64
-      language: cpp
-      dist: trusty
-      script:
-      - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
-      - unzip boost.zip
-      - mv boost src
-      - make
-      - mv bitmap2component bitmap2component_linux64
-    - stage: unit tests
-      os: osx
-      workspaces:
-        create:
-          name: osx-binaries      
-          paths:
-            - bitmap2component_osx
-      osx_image: xcode12u
-      language: cpp
-      script:
-      - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
-      - unzip boost.zip
-      - mv boost src
-      - make
-      - mv bitmap2component bitmap2component_osx
-    - stage: deploy
-      os: osx
-      language: minimal
-      sudo: true
-      workspaces:
-        use:
-          - linux-binaries
-          - osx-binaries
-          - windows-binaries
-      git:
-        clone: true
-      script:
-        - tar -zxvf ${CASHER_DIR}/linux-binaries-fetch.tgz
-        - tar -zxvf ${CASHER_DIR}/osx-binaries-fetch.tgz
-        - tar -zxvf ${CASHER_DIR}/windows-binaries-fetch.tgz
-        - mv home/travis/build/badgeek/svg2shenzhen/bitmap2component_linux64 ./inkscape/svg2shenzhen/bitmap2component_linux64
-        - mv ./C:/Users/travis/build/badgeek/svg2shenzhen/bitmap2component.exe ./inkscape/svg2shenzhen/bitmap2component.exe
-        - mv ./bitmap2component_osx ./inkscape/svg2shenzhen/
-        - sh build.sh
-      deploy:
-        provider: releases
-        api_key:
-          secure: KLiKx9YA0IMonTKywaxcdO00YCtXffJTmPlZj1edGAV1aKiWr8u9l5iW9qluNgUI/zeUCmJCJZj0V/k6U29E5lAbGRkngXfA0wqG3E4AxVPVjPQ17m2bipKJJRQjstrSgJCGjyNiBWVcAc3M2Ht/1TWEXFgzkjkBS8y0KdxO5vELgQ0e3MkTp+jTPqoPF7ap455nDydx5ck5wT9MWr+/JWcwnWcTzmVNemSeuwdp9q5xIlqhU0V8rFGBSf3NvRtIhH8DfCbEB/ZHF+qJk1AHFHP3rDaIEmCdvhBcZq3nNQToRKNpta4PO2OOq77ZHhck1oSqj/bLfIgD0m54fef6hyNLBsZskKxvWvC/ddCUolL5gQIntV9u6d8R50jYGTOIFjp9TrBoEgLa795Xiv4UfeXExc6C5lvZS6qOxT5gU0LnINb8lBBJIVK+/a4xDDE/F8IcGH+EeIKsGnncnH5Zb048bddGh/YHF5SLc7VjdCGFjMg4xp/RiBxrCPg545wmVf6GppUlpoYwC+rGjB/P+USpatYNIRW1Neh4+CAosPz8rrYA9g5tiW6SUdG4f0a98LlFcGCwQ79XwVwZGgyh+GhTSKGySypCAE7n0YfyVFcpR9USKqBcCRQVafAJm2B/59zx2Qfm2zOyEIwcfpURrFRMRnvolaaus0UmqSi51S0=
-        file_glob: true
-        file: "dist/*.*"
-        skip_cleanup: true
-        on:
-          tags: true
-          branch: master 
+  - stage: unit tests
+    os: windows
+    workspaces:
+      create:
+        name: windows-binaries
+        paths:
+        - bitmap2component.exe
+    language: cpp
+    compiler: cl
+    script:
+    - choco install make
+    - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
+    - unzip boost.zip
+    - mv boost src
+    - make
+  - stage: unit tests
+    os: linux
+    workspaces:
+      create:
+        name: linux-binaries
+        paths:
+        - bitmap2component_linux64
+    language: cpp
+    dist: trusty
+    script:
+    - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
+    - unzip boost.zip
+    - mv boost src
+    - make
+    - mv bitmap2component bitmap2component_linux64
+  - stage: unit tests
+    os: osx
+    workspaces:
+      create:
+        name: osx-binaries
+        paths:
+        - bitmap2component_osx
+    osx_image: xcode12u
+    language: cpp
+    script:
+    - wget https://github.com/badgeek/svg2shenzhen/files/2404261/boost.zip
+    - unzip boost.zip
+    - mv boost src
+    - make
+    - mv bitmap2component bitmap2component_osx
+  - stage: deploy
+    os: osx
+    language: minimal
+    sudo: true
+    workspaces:
+      use:
+      - linux-binaries
+      - osx-binaries
+      - windows-binaries
+    git:
+      clone: true
+    script:
+    - tar -zxvf ${CASHER_DIR}/linux-binaries-fetch.tgz
+    - tar -zxvf ${CASHER_DIR}/osx-binaries-fetch.tgz
+    - tar -zxvf ${CASHER_DIR}/windows-binaries-fetch.tgz
+    - mv home/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component_linux64 ./inkscape/svg2shenzhen/bitmap2component_linux64
+    - mv ./C:/Users/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component.exe
+      ./inkscape/svg2shenzhen/bitmap2component.exe
+    - mv ./bitmap2component_osx ./inkscape/svg2shenzhen/
+    - sh build.sh
+    deploy:
+      provider: releases
+      api_key:
+        secure: YTQy7sk6uuKvvln8MZmC+raWsT1Fkk+HJ+NS1LlO3TICHElKJvKxvjN7fEU1sQObCCizqMimqQ1ZLBsBMIj1NI8JLsqJsfMQgaU3OV4XbHHfYuDkTwFLC/epPYWshS89Rg7KwhAqD+Ws43PYiCXoRo9Z8Zosd4xxQbFY6K49Q01tHc+o1++nhYENjh2o/sNl7lJUU4oizsgQdsW/yMlJcwnXZHYj1A/sZYsZ3RjvdQ6KuUVVpYZx/QobHvC1VeORmJ66FT2gbamPPklqtr4WKY+965KmbiWrtFOto+mF/7nygIP2RrT4NdYDO9ded9swnBUyav+kKTKUW1l2GrvAJoiUs0vYC6J/H4irtHgXqh9rvbi77Whwpm9hZQFmXXzNjP3KWLH4H5q/nPA17cMI/by+kvuCNpAoEeHDK+4Tf3j+EgHs1it/usZgoA9NAMftArwzHfvQKnUB11pthnAQvk/S3U04sYXezvQkfLz6wxZcv1xMhuiU8Muz3gcXEFquVSjzFH6hgMfLSM/eFR3hVPU49EXDyF/5T1JlCaRI5fa9331nkGIOHjwlbrEwhyvWpW9FeT2RIXZIkQ37J5sd09Tzz7Cs8zCxB1S2mMDfn7KFkb/aP63JmRs4Otmr0k0+3BmuDhbFOcC6yFXTMl5es9ZQLHN/vl448QVZReuI27w=
+      file_glob: true
+      file: dist/*.*
+      skip_cleanup: true
+      on:
+        tags: true
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
         create:
           name: windows-binaries
           paths:
-          - bitmap2component.exe
+            - bitmap2component.exe
       language: cpp
       compiler: cl
       script:
@@ -21,7 +21,7 @@ jobs:
         create:
           name: linux-binaries
           paths:
-          - bitmap2component_linux64
+            - bitmap2component_linux64
       language: cpp
       dist: trusty
       script:
@@ -34,9 +34,9 @@ jobs:
       os: osx
       workspaces:
         create:
-          name: osx-binaries
+          name: osx-binaries      
           paths:
-          - bitmap2component_osx
+            - bitmap2component_osx
       osx_image: xcode12u
       language: cpp
       script:
@@ -51,26 +51,26 @@ jobs:
       sudo: true
       workspaces:
         use:
-        - linux-binaries
-        - osx-binaries
-        - windows-binaries
+          - linux-binaries
+          - osx-binaries
+          - windows-binaries
       git:
         clone: true
       script:
-      - tar -zxvf ${CASHER_DIR}/linux-binaries-fetch.tgz
-      - tar -zxvf ${CASHER_DIR}/osx-binaries-fetch.tgz
-      - tar -zxvf ${CASHER_DIR}/windows-binaries-fetch.tgz
-      - mv home/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component_linux64 ./inkscape/svg2shenzhen/bitmap2component_linux64
-      - mv ./C:/Users/travis/build/Sodium-Hydrogen/svg2shenzhen/bitmap2component.exe ./inkscape/svg2shenzhen/bitmap2component.exe
-      - mv ./bitmap2component_osx ./inkscape/svg2shenzhen/
-      - sh build.sh
+        - tar -zxvf ${CASHER_DIR}/linux-binaries-fetch.tgz
+        - tar -zxvf ${CASHER_DIR}/osx-binaries-fetch.tgz
+        - tar -zxvf ${CASHER_DIR}/windows-binaries-fetch.tgz
+        - mv home/travis/build/badgeek/svg2shenzhen/bitmap2component_linux64 ./inkscape/svg2shenzhen/bitmap2component_linux64
+        - mv ./C:/Users/travis/build/badgeek/svg2shenzhen/bitmap2component.exe ./inkscape/svg2shenzhen/bitmap2component.exe
+        - mv ./bitmap2component_osx ./inkscape/svg2shenzhen/
+        - sh build.sh
       deploy:
         provider: releases
         api_key:
-          secure: YTQy7sk6uuKvvln8MZmC+raWsT1Fkk+HJ+NS1LlO3TICHElKJvKxvjN7fEU1sQObCCizqMimqQ1ZLBsBMIj1NI8JLsqJsfMQgaU3OV4XbHHfYuDkTwFLC/epPYWshS89Rg7KwhAqD+Ws43PYiCXoRo9Z8Zosd4xxQbFY6K49Q01tHc+o1++nhYENjh2o/sNl7lJUU4oizsgQdsW/yMlJcwnXZHYj1A/sZYsZ3RjvdQ6KuUVVpYZx/QobHvC1VeORmJ66FT2gbamPPklqtr4WKY+965KmbiWrtFOto+mF/7nygIP2RrT4NdYDO9ded9swnBUyav+kKTKUW1l2GrvAJoiUs0vYC6J/H4irtHgXqh9rvbi77Whwpm9hZQFmXXzNjP3KWLH4H5q/nPA17cMI/by+kvuCNpAoEeHDK+4Tf3j+EgHs1it/usZgoA9NAMftArwzHfvQKnUB11pthnAQvk/S3U04sYXezvQkfLz6wxZcv1xMhuiU8Muz3gcXEFquVSjzFH6hgMfLSM/eFR3hVPU49EXDyF/5T1JlCaRI5fa9331nkGIOHjwlbrEwhyvWpW9FeT2RIXZIkQ37J5sd09Tzz7Cs8zCxB1S2mMDfn7KFkb/aP63JmRs4Otmr0k0+3BmuDhbFOcC6yFXTMl5es9ZQLHN/vl448QVZReuI27w=
+          secure: KLiKx9YA0IMonTKywaxcdO00YCtXffJTmPlZj1edGAV1aKiWr8u9l5iW9qluNgUI/zeUCmJCJZj0V/k6U29E5lAbGRkngXfA0wqG3E4AxVPVjPQ17m2bipKJJRQjstrSgJCGjyNiBWVcAc3M2Ht/1TWEXFgzkjkBS8y0KdxO5vELgQ0e3MkTp+jTPqoPF7ap455nDydx5ck5wT9MWr+/JWcwnWcTzmVNemSeuwdp9q5xIlqhU0V8rFGBSf3NvRtIhH8DfCbEB/ZHF+qJk1AHFHP3rDaIEmCdvhBcZq3nNQToRKNpta4PO2OOq77ZHhck1oSqj/bLfIgD0m54fef6hyNLBsZskKxvWvC/ddCUolL5gQIntV9u6d8R50jYGTOIFjp9TrBoEgLa795Xiv4UfeXExc6C5lvZS6qOxT5gU0LnINb8lBBJIVK+/a4xDDE/F8IcGH+EeIKsGnncnH5Zb048bddGh/YHF5SLc7VjdCGFjMg4xp/RiBxrCPg545wmVf6GppUlpoYwC+rGjB/P+USpatYNIRW1Neh4+CAosPz8rrYA9g5tiW6SUdG4f0a98LlFcGCwQ79XwVwZGgyh+GhTSKGySypCAE7n0YfyVFcpR9USKqBcCRQVafAJm2B/59zx2Qfm2zOyEIwcfpURrFRMRnvolaaus0UmqSi51S0=
         file_glob: true
         file: "dist/*.*"
         skip_cleanup: true
         on:
           tags: true
-          branch: master
+          branch: master 

--- a/inkscape/svg2shenzhen_export.inx
+++ b/inkscape/svg2shenzhen_export.inx
@@ -13,7 +13,10 @@
     <param name="threshold" type="int" min="0" max="255" _gui-text="Threshold (!)" _gui-description="Default: 5 - Define the threshold the black and white will have.">5</param>
     <param name="dpi" type="int" min="0" max="10000" _gui-text="Export DPI (!)" _gui-description="Default: 1200 - Define the Dots Per Inch to Export the Layers at, recommended is 1,200, max is 10,000.  Below 1,200 you may see artifacts due to the low resolution.">1200</param>
     <separator />
+    <param name="centermodule" type="boolean" _gui-text="Center Module (!)" _gui-description="Select this option if you would like the origin of module(s) to be centered instead of the top left corner.">true</param>
+    <param name="createpads" type="boolean" _gui-text="Create Metal Pads (!)" _gui-description="Select this option if you want all copper layers to be converted to pads.">false</param>
     <param name="autoflatten" type="boolean" _gui-text="Flatten Bezier (!)" _gui-description="Select this option if you have not flattened the Bezier Curves on your Edge.Cut layer.  If this is not the first time you have exported this drawing do not check this option.">false</param>
+    <separator />
     <param name="openfactory" type="boolean" gui-text="Open PCBWay (!)" _gui-description="Opens the PCBWay website with an affiliate link for you to submit an order.">false</param>
     <param name="openkicad" type="boolean" gui-text="Open KiCad (!)" _gui-description="Opens the KiCad for you.">false</param>
     <param name="debug" type="boolean" _gui-text="Debug Mode" _gui-description="Only necessary for troubleshooting.">false</param>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,8 @@ using namespace std;
 
 extern int bitmap2component( potrace_bitmap_t* aPotrace_bitmap, FILE* aOutfile,
                              OUTPUT_FMT_ID aFormat, int aDpi_X, int aDpi_Y,
-                             BMP2CMP_MOD_LAYER aModLayer, const char * layer_name = NULL );
+                             BMP2CMP_MOD_LAYER aModLayer, const char * layer_name = NULL,
+			     bool center = true, bool createPad = false );
 
 
 string pcb_header = "(kicad_pcb (version 4) (host pcbnew 4.0.7)"
@@ -125,7 +126,7 @@ void showUsage()
   cout<<" bitmap2component-cli "<<endl;
   cout<<"" << endl;
   cout<<" Usage"<<endl;
-  cout<<" ./bitmap2component <filename.png> <output filename> <layer> <negative|true/false> <dpi> <threshold|0-255>"<<endl;
+  cout<<" ./bitmap2component <filename.png> <output filename> <layer> <negative|true/false> <dpi> <threshold|0-255> <center|true/false> <create pads|true/false>"<<endl;
   cout<<"\n\n\n" << endl;
 }
 
@@ -137,6 +138,8 @@ int main(int argc, char* argv[])
     int dpi = 600;
     string image_filename;
     string output_filename;
+    bool center = true;
+    bool createPad = false;
 
 
     BMP2CMP_MOD_LAYER kicad_output_layer = MOD_LYR_FCU;
@@ -169,6 +172,22 @@ int main(int argc, char* argv[])
     if (argc > 6){
         threshold = stoi(string(argv[6]));
     }      
+
+    if (argc > 7){
+	if (string(argv[7]) == "true"){
+		center = true;
+	}else{
+		center = false;
+	}
+    }
+
+    if (argc > 8){
+	if (string(argv[8]) == "true"){
+		createPad = true;
+	}else{
+		createPad = false;
+	}
+    }
 
     printf("[bitmap2component] Filename %s\n", image_filename.c_str());
 
@@ -233,7 +252,7 @@ int main(int argc, char* argv[])
    printf("[bitmap2component] Trace image\n");
 
 //    fprintf(pFile, pcb_header.c_str());
-   bitmap2component( potrace_bitmap, pFile, PCBNEW_KICAD_MOD, dpi, dpi, kicad_output_layer, layer_name );
+   bitmap2component( potrace_bitmap, pFile, PCBNEW_KICAD_MOD, dpi, dpi, kicad_output_layer, layer_name, center, createPad);
 //    fprintf(pFile, pcb_footer.c_str());
 
 


### PR DESCRIPTION
Artwork on copper layers has been an issue with DRC not noticing the artwork and allowing shorts similar to the pictured one.

<img src="https://user-images.githubusercontent.com/42423149/95160726-7d926b00-075e-11eb-8fbd-ac6fb708a4dc.png" width=300>

This pull does the following:
+ Adds an option to convert all copper layers in artwork to pads that the DRC will acknowledge and show errors for shorts and prevent the pictured mistake.
+ Adds an option to change the origin location to the top left corner to match the origin location of SVG images.